### PR TITLE
refactor: remove redundancy and simplify checks

### DIFF
--- a/kala-common/src/crypto.rs
+++ b/kala-common/src/crypto.rs
@@ -55,12 +55,12 @@ impl CryptoUtils {
 
     /// Validate public key format
     pub fn validate_pubkey(pubkey: &PublicKey) -> bool {
-        !PublicKeyExt::is_zero(pubkey) && pubkey.iter().any(|&b| b != 0)
+        !pubkey.is_zero()
     }
 
     /// Validate signature format
     pub fn validate_signature(signature: &Signature) -> bool {
-        !SignatureExt::is_zero(signature) && signature.iter().any(|&b| b != 0)
+        !signature.is_zero()
     }
 
     /// Convert hex string to hash

--- a/kala-common/src/network.rs
+++ b/kala-common/src/network.rs
@@ -15,7 +15,8 @@ use crate::serialization::{EncodingType, KalaSerialize, NetworkMessage};
 pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Maximum message size (16MB)
-pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+/// Re-exported from [`crate::types::network`] to avoid duplication.
+pub use crate::types::network::MAX_MESSAGE_SIZE;
 
 /// Network node identifier
 pub type NodeId = [u8; 32];

--- a/kala-common/src/types.rs
+++ b/kala-common/src/types.rs
@@ -128,53 +128,27 @@ impl VersionInfo {
 }
 
 /// Utility functions for common operations using extension traits
-pub trait HashExt {
-    /// Create a zero hash
-    fn zero() -> Self;
-    /// Check if hash is zero
-    fn is_zero(&self) -> bool;
+macro_rules! impl_byte_array_ext {
+    ($name:ident, $len:expr) => {
+        pub trait $name {
+            /// Create an array filled with zeros
+            fn zero() -> Self;
+            /// Check if every byte in the array is zero
+            fn is_zero(&self) -> bool;
+        }
+
+        impl $name for [u8; $len] {
+            fn zero() -> Self {
+                [0u8; $len]
+            }
+
+            fn is_zero(&self) -> bool {
+                self.iter().all(|&b| b == 0)
+            }
+        }
+    };
 }
 
-impl HashExt for Hash {
-    fn zero() -> Self {
-        [0u8; 32]
-    }
-
-    fn is_zero(&self) -> bool {
-        *self == [0u8; 32]
-    }
-}
-
-pub trait PublicKeyExt {
-    /// Create a zero public key
-    fn zero() -> Self;
-    /// Check if public key is zero
-    fn is_zero(&self) -> bool;
-}
-
-impl PublicKeyExt for PublicKey {
-    fn zero() -> Self {
-        [0u8; 32]
-    }
-
-    fn is_zero(&self) -> bool {
-        *self == [0u8; 32]
-    }
-}
-
-pub trait SignatureExt {
-    /// Create a zero signature
-    fn zero() -> Self;
-    /// Check if signature is zero
-    fn is_zero(&self) -> bool;
-}
-
-impl SignatureExt for Signature {
-    fn zero() -> Self {
-        [0u8; 64]
-    }
-
-    fn is_zero(&self) -> bool {
-        *self == [0u8; 64]
-    }
-}
+impl_byte_array_ext!(HashExt, 32);
+impl_byte_array_ext!(PublicKeyExt, 32);
+impl_byte_array_ext!(SignatureExt, 64);


### PR DESCRIPTION
## Summary
- re-export network size constant to avoid duplication
- simplify crypto validation helpers
- generate extension traits with a macro

## Testing
- `cargo test` *(fails: failed to get `tempfile` dependency (CONNECT tunnel failed, response 403))*
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68ae696042108329ae93236725a4d546